### PR TITLE
chore: simplify root requirements.txt with `-e .`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,1 @@
-Django==3.1.7
-django-timezone-field==4.1.1
-django-celery-beat==2.2.0
-django-tenants==3.2.1
-tenant-schemas-celery==1.0.1
+-e .


### PR DESCRIPTION
`pip install -r requirements.txt` will first install the package,
then its dependencies as listed in `install_requires`.

See https://caremad.io/posts/2013/07/setup-vs-requirement/