### PR TITLE
fix: allow setting the tenant when creating new periodic task

### DIFF
--- a/django_tenants_celery_beat/admin.py
+++ b/django_tenants_celery_beat/admin.py
@@ -3,7 +3,7 @@ from django.db.models import F
 
 from django_celery_beat.admin import PeriodicTaskAdmin
 from django_celery_beat.models import PeriodicTask
-from django_tenants.utils import get_public_schema_name
+from django_tenants.utils import get_tenant_model, get_public_schema_name
 
 from django_tenants_celery_beat.models import PeriodicTaskTenantLink
 
@@ -12,8 +12,26 @@ class PeriodicTaskTenantLinkInline(admin.StackedInline):
     model = PeriodicTaskTenantLink
     can_delete = False
 
+    def get_formset(self, request, obj=None, **kwargs):
+        formset = super().get_formset(request, obj, **kwargs)
+        if obj is None:
+            # Only for adding a new PeriodicTask
+            formset.form.base_fields["tenant"].initial = request.tenant
+            if request.tenant.schema_name != get_public_schema_name():
+                # Hide all other Tenants
+                # Need to make the field non-readonly as otherwise the default value
+                # is blank, and the PeriodicTask will be created with no Tenant, which
+                # means it is then lost to the public schema
+                formset.form.base_fields["tenant"].queryset = (
+                    get_tenant_model().objects.filter(pk=request.tenant.pk)
+                )
+        return formset
+
     def get_readonly_fields(self, request, obj=None):
         if request.tenant.schema_name == get_public_schema_name():
+            return tuple()
+        if obj is None:
+            # For new PeriodicTasks, we need to set the Tenant
             return tuple()
         return ("tenant",)
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="django-tenants-celery-beat",
-    version="0.1.0",
+    version="0.1.1",
     author="David Vaughan",
     author_email="david.vaughan@quickrelease.co.uk",
     maintainer="Quick Release (Automotive) Ltd.",


### PR DESCRIPTION
This makes it possible to add a new PeriodicTask while on a Tenant-level
admin and set the Tenant on the PeriodicTaskTenantLink correctly.
Previously, you couldn't set the Tenant because it is readonly, which then
meant that once you saved the PeriodicTask, it was on the public schema,
and therefore wouldn't show up on the Tenant's admin.