### PR TITLE
fix: Update models.py

### DIFF
--- a/django_tenants_celery_beat/models.py
+++ b/django_tenants_celery_beat/models.py
@@ -13,9 +13,6 @@ from django_tenants_celery_beat.utils import get_periodic_task_tenant_link_model
 class TenantTimezoneMixin(models.Model):
     timezone = timezone_field.TimeZoneField(
         default="UTC",
-        display_GMT_offset=getattr(
-            settings, "TENANT_TIMEZONE_DISPLAY_GMT_OFFSET", False
-        ),
     )
 
     class Meta:


### PR DESCRIPTION
    display_GMT_offset=getattr(
            settings, "TENANT_TIMEZONE_DISPLAY_GMT_OFFSET", False
        ),

TypeError: __init__() got an unexpected keyword argument 'display_GMT_offset'

Django throws this error when I am using the package but when I remove the field it works fine. I wonder what's the matter. Do you think you can help me here. Thank you